### PR TITLE
Simplify PAL since timestamps are now always nanoseconds.

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetTimestamp.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetTimestamp.cs
@@ -7,9 +7,6 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestampResolution", ExactSpelling = true)]
-        internal static extern ulong GetTimestampResolution();
-
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestamp", ExactSpelling = true)]
         [SuppressGCTransition]
         internal static extern ulong GetTimestamp();

--- a/src/libraries/Native/Unix/System.Native/pal_time.c
+++ b/src/libraries/Native/Unix/System.Native/pal_time.c
@@ -47,28 +47,6 @@ int32_t SystemNative_UTimensat(const char* path, TimeSpec* times)
     return result;
 }
 
-// Gets the number of "ticks per second" of the underlying monotonic timer.
-//
-// On most Unix platforms, the methods that query the resolution return a value
-// that is "nanoseconds per tick" in which case we need to scale before returning.
-uint64_t SystemNative_GetTimestampResolution()
-{
-#if HAVE_CLOCK_GETTIME_NSEC_NP
-    if (clock_gettime_nsec_np(CLOCK_UPTIME_RAW) == 0)
-    {
-        return 0;
-    }
-#endif
-    // clock_gettime() returns a result in terms of nanoseconds rather than a count. This
-    // means that we need to either always scale the result by the actual resolution (to
-    // get a count) or we need to say the resolution is in terms of nanoseconds. We prefer
-    // the latter since it allows the highest throughput and should minimize error propagated
-    // to the user.
-
-    return SecondsToNanoSeconds;
-
-}
-
 uint64_t SystemNative_GetTimestamp()
 {
 #if HAVE_CLOCK_GETTIME_NSEC_NP
@@ -98,17 +76,14 @@ int32_t SystemNative_GetCpuUtilization(ProcessCpuInformation* previousCpuInfo)
     else
     {
         kernelTime =
-            ((uint64_t)(resUsage.ru_stime.tv_sec) * SecondsToNanoSeconds) + 
+            ((uint64_t)(resUsage.ru_stime.tv_sec) * SecondsToNanoSeconds) +
             ((uint64_t)(resUsage.ru_stime.tv_usec) * MicroSecondsToNanoSeconds);
         userTime =
             ((uint64_t)(resUsage.ru_utime.tv_sec) * SecondsToNanoSeconds) +
             ((uint64_t)(resUsage.ru_utime.tv_usec) * MicroSecondsToNanoSeconds);
     }
 
-    uint64_t resolution = SystemNative_GetTimestampResolution();
-    uint64_t timestamp = SystemNative_GetTimestamp();
-
-    uint64_t currentTime = (uint64_t)((double)timestamp * ((double)SecondsToNanoSeconds / (double)resolution));
+    uint64_t currentTime = SystemNative_GetTimestamp();
 
     uint64_t lastRecordedCurrentTime = previousCpuInfo->lastRecordedCurrentTime;
     uint64_t lastRecordedKernelTime = previousCpuInfo->lastRecordedKernelTime;

--- a/src/libraries/Native/Unix/System.Native/pal_time.h
+++ b/src/libraries/Native/Unix/System.Native/pal_time.h
@@ -28,11 +28,6 @@ typedef struct ProcessCpuInformation
 PALEXPORT int32_t SystemNative_UTimensat(const char* path, TimeSpec* times);
 
 /**
- * Gets the resolution of the timestamp, in counts per second.
- */
-PALEXPORT uint64_t SystemNative_GetTimestampResolution(void);
-
-/**
  * Gets a high-resolution timestamp that can be used for time-interval measurements.
  */
 PALEXPORT uint64_t SystemNative_GetTimestamp(void);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.Unix.cs
@@ -7,7 +7,8 @@ namespace System.Diagnostics
     {
         private static long QueryPerformanceFrequency()
         {
-            return (long)Interop.Sys.GetTimestampResolution();
+            const long SecondsToNanoSeconds = 1000000000;
+            return SecondsToNanoSeconds;
         }
 
         private static long QueryPerformanceCounter()


### PR DESCRIPTION
Here is what I think Jan is suggesting.

1. `clock_gettime_nsec_np` is supported on all Apple platforms that we care about. If I recall correctly, it's macOS 10.12+ (and .NET Core will not run on anything below 10.13 last time I looked).

2. The PAL exists for both macOS and Linux. On Linux, we are using `clock_gettime(CLOCK_MONOTONIC)` to get the timestamp. This is always in nanoseconds, as it is written.

    Previously, on macOS we were using `mach_timebase_info` which gives us some _N_ number of ticks. We needed to convert those ticks to nanoseconds which was the job of `GetTimestampResolution`. However, `clock_gettime_nsec_np` will always return the number of nanoseconds. Thus, `SystemNative_GetTimestampResolution` with the change doesn't really serve any purpose anymore. It will only return `SecondsToNanoSeconds`. So we can get rid of the whole thing since everyone now agrees "SystemNative_GetTimestamp is in nanoseconds". So let's get rid of it and use `SecondsToNanoSeconds` directly.


    As such, this code block gets a lot simpler. We started off with this:

    ```c#
    uint64_t resolution = SystemNative_GetTimestampResolution();
    uint64_t timestamp = SystemNative_GetTimestamp();

    uint64_t currentTime = (uint64_t)((double)timestamp * ((double)SecondsToNanoSeconds / (double)resolution));
    ```

    but we know `resolution` is now going to be `SecondsToNanoSeconds`. So now we get:

    ```c#
    uint64_t timestamp = SystemNative_GetTimestamp();

    uint64_t currentTime = (uint64_t)((double)timestamp * ((double)SecondsToNanoSeconds / (double)SecondsToNanoSeconds));
    ```

    okay but `SecondsToNanoSeconds / SecondsToNanoSeconds` is 1, so now we have:

    ```c#
    uint64_t timestamp = SystemNative_GetTimestamp();

    uint64_t currentTime = (uint64_t)((double)timestamp * 1);
    ```

    and you can see where this is probably going. `currentTime` just ends up being `timestamp`, so we can get rid of all that.

Some disclaimers just to be sure:

1. This _seems_ right to me, hopefully I have not massively understood what is going on here. Apologies if this is all incorrect. I've done some validation that this is correct but nothing exhaustive.

2. Please use this code freely in your own PR if you would like to. I do not require any attribution and waive my rights to the changes in this pull request.